### PR TITLE
expose javaInit method to futher extend functionality on client side

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
 exports.HLConsumer = require('./lib/hlConsumer');
 exports.StringProducer = require('./lib/stringProducer');
 exports.BinaryProducer = require('./lib/binaryProducer');
+exports.javaInit = require('./lib/util/javaInit');

--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -5,14 +5,14 @@ function parseData(parsingContext) {
     if (parsingContext.currentMessage.remainingSize > 0) {
         newMessage = _parseNextMessage(parsingContext);
         if (newMessage) {
-            _onNewMessage(newMessage, parsingContext)
+            _onNewMessage(newMessage, parsingContext);
         }
     }
     while (parsingContext.offset < parsingContext.data.length) {
         _readMsgSize(parsingContext);
         newMessage = _parseNextMessage(parsingContext);
         if (newMessage) {
-            _onNewMessage(newMessage, parsingContext)
+            _onNewMessage(newMessage, parsingContext);
         }
     }
 }


### PR DESCRIPTION
I need access to kafka admin utils to do some admin work. Exposing javaInit method makes it much easier to extend functionality.

**const javaInit = require('kafka-java-bridge').javaInit;
const java = javaInit.getJavaInstance()**

Example:- 
const adminUtils = java.import("kafka.admin.AdminUtils")
const ZKStringSerializer = java.import("kafka.utils.ZKStringSerializer$")
const ZKUtils = java.import("kafka.utils.ZkUtils")
const ZkClient = java.import("org.I0Itec.zkclient.ZkClient")
const zkClient = new ZkClient(`${kafkaConf.host}:${kafkaConf.port}`, 10 * 1000, 8 * 1000, ZKStringSerializer.MODULE$)
const topicProperties = java.newInstanceSync("java.util.Properties")


/**
 * Creates a topic with specified number of partitions and replication factor
 * It is a Synchronous method
 * @param name {string} - name of the topic
 * @param numPartitions {number}
 * @param replicationFactor {number}
 * @returns void
 */
function createTopic(name, numPartitions, replicationFactor) {
    try {
        adminUtils.createTopicSync(zkClient, name, numPartitions, replicationFactor,topicProperties)
    } catch (ex) {
        throw ex
    }
}